### PR TITLE
Add pathname to log format line

### DIFF
--- a/src/pysdl/logger_config.py
+++ b/src/pysdl/logger_config.py
@@ -6,7 +6,7 @@ logging_dict = {
     'formatters': {
         "json": {
             '()': "pysdl.stackdriverjsonlogger.StackdriverJsonFormatter",
-            'format': "%(levelname)s %(asctime)s %(module)s %(funcName)s %(lineno)s %(process)s %(thread)s %(message)s"
+            'format': "%(levelname)s %(asctime)s %(module)s %(funcName)s %(lineno)s %(pathname)s %(process)s %(thread)s %(message)s"
         },
         "medium": {
             'format': '%(levelname)s %(asctime)s [%(correlation_id)s] %(name)s %(message)s'


### PR DESCRIPTION
adds pathname to log format line. This will make it easier to figure out which specific file a log line came from
https://docs.python.org/3/library/logging.html#logrecord-attributes
