### PR TITLE
removing info logs from request handling

### DIFF
--- a/src/pysdl/logger_config.py
+++ b/src/pysdl/logger_config.py
@@ -26,6 +26,11 @@ logging_dict = {
             'handlers': ['console'],
             'level': 'INFO',
         },
+        # Change request handling logs to only log when an error happens
+        'django.request': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+        },
         # DB events and sql
         'django.db.backends': {
             'handlers': ['console'],


### PR DESCRIPTION
This is a PR to remove the logs that consume ~75% of our logging.  Examples are:


"pid: 319|app: 0|req: 19/305] 10.3.0.100 () {26 vars in 315 bytes} [Thu Nov 16 19:45:26 2023] GET /readyz => generated 44 bytes in 31 msecs (HTTP/1.1 200) 10 headers in 344 bytes (2 switches on core 4)"


These logs don't really help and cost $$$